### PR TITLE
update autoperf for darshan 3.4.0 module API changes

### DIFF
--- a/apxc/lib/darshan-apxc.c
+++ b/apxc/lib/darshan-apxc.c
@@ -152,7 +152,9 @@ static void capture(struct darshan_apxc_perf_record *rec,
 void apxc_runtime_initialize()
 {
     size_t apxc_buf_size;
+    size_t apxc_rec_count = 1;
     char rtr_rec_name[128];
+    int ret;
 
     darshan_module_funcs mod_funcs = {
 //#ifdef HAVE_MPI
@@ -177,12 +179,18 @@ void apxc_runtime_initialize()
                     sizeof(struct darshan_apxc_perf_record);
 
     /* register the APXC module with the darshan-core component */
-    darshan_core_register_module(
+    ret = darshan_core_register_module(
         DARSHAN_APXC_MOD,
         mod_funcs,
-        &apxc_buf_size,
+        apxc_buf_size,
+        &apxc_rec_count,
         &my_rank,
         NULL);
+    if(ret < 0)
+    {
+        APXC_UNLOCK();
+        return;
+    }
 
 
     /* initialize module's global state */


### PR DESCRIPTION
There were some small changes to the Darshan core module API as part of https://github.com/darshan-hpc/darshan/pull/703: 

- `darshan_core_register_module()` now takes a fixed record size input and an input/output record count -- this is a really small change since AutoPerf modules only use 1 record per-process anyways
- `darshan_core_register_module()`  now returns 0 on success and -1 on failure -- on failure, modules need to stop initializing and avoid instrumenting anything

I also added a small change to APMPI so that it won't repeatedly try to init if it fails the first time. 

I marked this as WIP until the PR on the Darshan repo lands -- once that's in, feel free to remove the resolve the WIP status and merge.